### PR TITLE
Forward the protocal to the app.

### DIFF
--- a/lib/apartment_acme_client/nginx_configuration/real.rb
+++ b/lib/apartment_acme_client/nginx_configuration/real.rb
@@ -83,6 +83,7 @@ module ApartmentAcmeClient
 
             location @app {
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-FORWARDED-PROTO $scheme;
                 proxy_set_header Host $http_host;
                 proxy_redirect off;
                 proxy_pass http://app;


### PR DESCRIPTION
Without this, the app doesn't know that it's being requested over https, and may cause
a redirect-to-https loop issue