### PR TITLE
Acme v2 with wildcard domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Future features
 
+# 0.0.4
+
+* Use ACMEv2 client
+* Enable provisioning Wildcard certificate
+* Use AWS Route53 API for creating wildcard certificate
+
 # 0.0.3
 
 * Allow Rails 5.2.x

--- a/apartment_acme_client.gemspec
+++ b/apartment_acme_client.gemspec
@@ -26,8 +26,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "acme-client", "~> 0.3.1"
+  spec.add_runtime_dependency 'acme-client', '~> 2.0.0'
   spec.add_runtime_dependency "aws-sdk-s3", "~> 1"
+  spec.add_runtime_dependency "aws-sdk-route53", "~> 1"
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/apartment_acme_client.gemspec
+++ b/apartment_acme_client.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'acme-client', '~> 2.0.0'
-  spec.add_runtime_dependency "aws-sdk-s3", "~> 1"
   spec.add_runtime_dependency "aws-sdk-route53", "~> 1"
+  spec.add_runtime_dependency "aws-sdk-s3", "~> 1"
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/apartment_acme_client.rb
+++ b/lib/apartment_acme_client.rb
@@ -7,6 +7,9 @@ require "apartment_acme_client/acme_client/proxy"
 require "apartment_acme_client/acme_client/real_client"
 require "apartment_acme_client/certificate_storage/proxy"
 require "apartment_acme_client/certificate_storage/s3"
+require "apartment_acme_client/dns_api/check_dns"
+require "apartment_acme_client/dns_api/fake"
+require "apartment_acme_client/dns_api/route53"
 require "apartment_acme_client/nginx_configuration/proxy"
 require "apartment_acme_client/nginx_configuration/real"
 require "apartment_acme_client/file_manipulation/proxy"
@@ -26,6 +29,9 @@ module ApartmentAcmeClient
       @@domains_to_check
     end
   end
+
+  # An optional domain which will we request a wildcard certificate for
+  mattr_accessor :wildcard_domain
 
   # The base domain, a domain which is always going to be accessible.
   # because we need a common domain to be used on each request.

--- a/lib/apartment_acme_client/acme_client/real_client.rb
+++ b/lib/apartment_acme_client/acme_client/real_client.rb
@@ -17,7 +17,7 @@ module ApartmentAcmeClient
       def register(email)
         # If the private key is not known to the server, we need to register it for the first time.
         account = @client.new_account(contact: "mailto:#{email}", terms_of_service_agreed: true)
-        Rollbar.notice("New Let's Encrypt Account created with KID: #{account.kid}")
+        Rollbar.info("New Let's Encrypt Account created with KID: #{account.kid}")
 
         true
       end
@@ -26,12 +26,16 @@ module ApartmentAcmeClient
         @client.authorize(domain: domain)
       end
 
+      def new_order(identifiers:)
+        @client.new_order(identifiers: identifiers)
+      end
+
       # Create a Certificate for our new set of domain names
       # returns that certificate
       def request_certificate(common_name:, names:, order:)
         # We're going to need a certificate signing request. If not explicitly
         # specified, the first name listed becomes the common name.
-        csr = Acme::Client::CertificateRequest.new(private_key: csr_private_key, subject: { common_name: common_name, names: names })
+        csr = Acme::Client::CertificateRequest.new(private_key: csr_private_key, common_name: common_name, names: names)
         order.finalize(csr: csr)
         while order.status == 'processing'
           sleep(1)

--- a/lib/apartment_acme_client/acme_client/real_client.rb
+++ b/lib/apartment_acme_client/acme_client/real_client.rb
@@ -1,21 +1,23 @@
+# frozen_string_literal: true
+
 require 'acme-client'
 
 module ApartmentAcmeClient
   module AcmeClient
     class RealClient
-      def initialize(private_key:)
+      attr_reader :csr_private_key
+      def initialize(acme_client_private_key:, csr_private_key:)
         @client = Acme::Client.new(
-          private_key: private_key,
-          endpoint: server_endpoint,
+          private_key: acme_client_private_key,
+          directory: server_directory
         )
+        @csr_private_key = csr_private_key
       end
 
       def register(email)
         # If the private key is not known to the server, we need to register it for the first time.
-        registration = @client.register(contact: "mailto:#{email}")
-
-        # You may need to agree to the terms of service (that's up the to the server to require it or not but boulder does by default)
-        registration.agree_terms
+        account = @client.new_account(contact: "mailto:#{email}", terms_of_service_agreed: true)
+        Rollbar.notice("New Let's Encrypt Account created with KID: #{account.kid}")
 
         true
       end
@@ -26,29 +28,29 @@ module ApartmentAcmeClient
 
       # Create a Certificate for our new set of domain names
       # returns that certificate
-      def request_certificate(common_name:, domains:)
+      def request_certificate(common_name:, names:, order:)
         # We're going to need a certificate signing request. If not explicitly
         # specified, the first name listed becomes the common name.
-        csr = Acme::Client::CertificateRequest.new(common_name: common_name, names: domains)
+        csr = Acme::Client::CertificateRequest.new(private_key: csr_private_key, subject: { common_name: common_name, names: names })
+        order.finalize(csr: csr)
+        while order.status == 'processing'
+          sleep(1)
+          order.reload
+        end
 
-        # We can now request a certificate. You can pass anything that returns
-        # a valid DER encoded CSR when calling to_der on it. For example an
-        # OpenSSL::X509::Request should work too.
-        certificate = @client.new_certificate(csr) # => #<Acme::Client::Certificate ....>
-
-        certificate
+        order.certificate
       end
 
       private
 
-      def server_endpoint
+      def server_directory
         # We need an ACME server to talk to, see github.com/letsencrypt/boulder
         # WARNING: This endpoint is the production endpoint, which is rate limited and will produce valid certificates.
         # You should probably use the staging endpoint for all your experimentation:
         if ApartmentAcmeClient.lets_encrypt_test_server_enabled
-          'https://acme-staging.api.letsencrypt.org/'
+          'https://acme-staging-v02.api.letsencrypt.org/directory'
         else
-          'https://acme-v01.api.letsencrypt.org/'
+          'https://acme-v02.api.letsencrypt.org/directory'
         end
       end
     end

--- a/lib/apartment_acme_client/certificate_storage/s3.rb
+++ b/lib/apartment_acme_client/certificate_storage/s3.rb
@@ -10,7 +10,7 @@ module ApartmentAcmeClient
                          TEST_PREFIX
                        else
                          ''
-        end
+                       end
       end
 
       ENCRYPTION_S3_NAME = 'server_encryption_client_private_key.der'
@@ -55,7 +55,6 @@ module ApartmentAcmeClient
       def save_csr_private_key(private_key)
         store_s3_file(csr_private_key_s3_filename, private_key.to_der)
       end
-
 
       private
 

--- a/lib/apartment_acme_client/certificate_storage/s3.rb
+++ b/lib/apartment_acme_client/certificate_storage/s3.rb
@@ -16,17 +16,14 @@ module ApartmentAcmeClient
       ENCRYPTION_S3_NAME = 'server_encryption_client_private_key.der'
       CSR_ENCRYPTION_S3_NAME = 'csr_server_encryption_client_private_key.der'
 
-      def store_certificate(certificate)
-        # Save the certificate and the private key to files
-        File.write(cert_path('privkey.pem'), certificate.request.private_key.to_pem)
-        File.write(cert_path('cert.pem'), certificate.to_pem)
-        File.write(cert_path('chain.pem'), certificate.chain_to_pem)
-        File.write(cert_path('fullchain.pem'), certificate.fullchain_to_pem)
+      def store_certificate_string(certificate_string)
+        File.write(cert_path('cert.pem'), certificate_string)
+        store_s3_file(derived_filename('cert.pem'), certificate_string)
+      end
 
-        store_s3_file(derived_filename('privkey.pem'), certificate.request.private_key.to_pem)
-        store_s3_file(derived_filename('cert.pem'), certificate.to_pem)
-        store_s3_file(derived_filename('chain.pem'), certificate.chain_to_pem)
-        store_s3_file(derived_filename('fullchain.pem'), certificate.fullchain_to_pem)
+      def store_csr_private_key_string(csr_private_key_string)
+        File.write(cert_path('privkey.pem'), csr_private_key_string)
+        store_s3_file(derived_filename('privkey.pem'), certificate_string)
       end
 
       # do we have a certificate on this server?
@@ -44,7 +41,7 @@ module ApartmentAcmeClient
       end
 
       def csr_private_key
-        s3_object = s3_file(private_key_s3_filename)
+        s3_object = s3_file(csr_private_key_s3_filename)
         return nil unless s3_object.exists?
 
         s3_object.get.body.read

--- a/lib/apartment_acme_client/certificate_storage/s3.rb
+++ b/lib/apartment_acme_client/certificate_storage/s3.rb
@@ -23,7 +23,7 @@ module ApartmentAcmeClient
 
       def store_csr_private_key_string(csr_private_key_string)
         File.write(cert_path('privkey.pem'), csr_private_key_string)
-        store_s3_file(derived_filename('privkey.pem'), certificate_string)
+        store_s3_file(derived_filename('privkey.pem'), csr_private_key_string)
       end
 
       # do we have a certificate on this server?

--- a/lib/apartment_acme_client/dns_api/check_dns.rb
+++ b/lib/apartment_acme_client/dns_api/check_dns.rb
@@ -29,7 +29,7 @@ module ApartmentAcmeClient
           rescue Resolv::ResolvError
             return false
           end
-          return false if !valid
+          return false unless valid
         end
 
         valid
@@ -40,7 +40,7 @@ module ApartmentAcmeClient
 
         @nameservers = []
         Resolv::DNS.open(nameserver: '8.8.8.8') do |dns|
-          while nameservers.length == 0
+          while nameservers.empty?
             @nameservers = dns.getresources(
               root_domain,
               Resolv::DNS::Resource::IN::NS
@@ -53,7 +53,7 @@ module ApartmentAcmeClient
 
       def wait_for_present(value, timeout_seconds: 60)
         time = 1
-        while !check_dns(value)
+        until check_dns(value)
           puts "Waiting for DNS to update"
           sleep 1
           time += 1

--- a/lib/apartment_acme_client/dns_api/check_dns.rb
+++ b/lib/apartment_acme_client/dns_api/check_dns.rb
@@ -6,7 +6,8 @@ module ApartmentAcmeClient
       attr_reader :root_domain, :dns_record
 
       def initialize(root_domain, dns_record)
-        @root_domain = root_domain
+        # ensure we only have the TLD, not a subdomain
+        @root_domain = root_domain.split(".").last(2).join(".")
         @dns_record = dns_record
       end
 
@@ -50,7 +51,7 @@ module ApartmentAcmeClient
         @nameservers
       end
 
-      def wait_for_present(value, timeout_seconds: 10)
+      def wait_for_present(value, timeout_seconds: 60)
         time = 1
         while !check_dns(value)
           puts "Waiting for DNS to update"

--- a/lib/apartment_acme_client/dns_api/check_dns.rb
+++ b/lib/apartment_acme_client/dns_api/check_dns.rb
@@ -1,0 +1,64 @@
+module ApartmentAcmeClient
+  module DnsApi
+    # Check to see if a particular DNS record is
+    # present.
+    class CheckDns
+      attr_reader :root_domain, :dns_record
+
+      def initialize(root_domain, dns_record)
+        @root_domain = root_domain
+        @dns_record = dns_record
+      end
+
+      # Search DNS recodrs for any entries which are TXT and include
+      # the text 'value'
+      def check_dns(value)
+        valid = true
+
+        nameservers.each do |nameserver|
+          begin
+            records = Resolv::DNS.open(nameserver: nameserver) do |dns|
+              dns.getresources(
+                dns_record,
+                Resolv::DNS::Resource::IN::TXT
+              )
+            end
+            records = records.map(&:strings).flatten
+            valid = records.include?(value)
+          rescue Resolv::ResolvError
+            return false
+          end
+          return false if !valid
+        end
+
+        valid
+      end
+
+      def nameservers
+        return @nameservers if defined?(@nameservers)
+
+        @nameservers = []
+        Resolv::DNS.open(nameserver: '8.8.8.8') do |dns|
+          while nameservers.length == 0
+            @nameservers = dns.getresources(
+              root_domain,
+              Resolv::DNS::Resource::IN::NS
+            ).map(&:name).map(&:to_s)
+          end
+        end
+
+        @nameservers
+      end
+
+      def wait_for_present(value, timeout_seconds: 10)
+        time = 1
+        while !check_dns(value)
+          puts "Waiting for DNS to update"
+          sleep 1
+          time += 1
+          break if time > timeout_seconds
+        end
+      end
+    end
+  end
+end

--- a/lib/apartment_acme_client/dns_api/fake.rb
+++ b/lib/apartment_acme_client/dns_api/fake.rb
@@ -1,0 +1,6 @@
+module ApartmentAcmeClient
+  module DnsApi
+    class Fake
+    end
+  end
+end

--- a/lib/apartment_acme_client/dns_api/route53.rb
+++ b/lib/apartment_acme_client/dns_api/route53.rb
@@ -28,7 +28,11 @@ module ApartmentAcmeClient
 
       # NOTE:
       # if you get error like:
-      # "Invalid Resource Record: FATAL problem: InvalidCharacterString (Value should be enclosed in quotation marks) encountered with <value>"
+      #
+      # "Invalid Resource Record: FATAL problem:
+      # InvalidCharacterString
+      # (Value should be enclosed in quotation marks) encountered with <value>"
+      #
       # this means that the "Value" should include escape quotes.
       # e.g. values: ["\"Something\"", "\"Other Thing\""]
       def write_record
@@ -62,8 +66,8 @@ module ApartmentAcmeClient
 
       def zone
         @zone = route53.list_hosted_zones(max_items: 100)
-                      .hosted_zones
-                      .detect { |z| z.name = '#{root_domain}.' }
+                       .hosted_zones
+                       .detect { |z| z.name = "#{root_domain}." }
       end
 
       def route53

--- a/lib/apartment_acme_client/dns_api/route53.rb
+++ b/lib/apartment_acme_client/dns_api/route53.rb
@@ -1,0 +1,82 @@
+require 'aws-sdk-route53'
+
+module ApartmentAcmeClient
+  module DnsApi
+    # based on https://www.petekeen.net/lets-encrypt-without-certbot
+    class Route53
+      # The domain being requested for DNS update
+      # e.g. "site.example.com"
+      attr_reader :requested_domain
+
+      # the DNS TXT record label (full label, including domain)
+      attr_reader :label
+
+      # will be TXT
+      attr_reader :record_type
+
+      # array of value keys to be written
+      # (for wildcard certs, you'll have one for *.example.com, and one for example.com)
+      # e.g. ["\"One\"", "\"Two\""]
+      attr_reader :values
+
+      def initialize(requested_domain:, dns_record_label:, record_type:, values:)
+        @requested_domain = requested_domain
+        @label = dns_record_label
+        @record_type = record_type
+        @values = values
+      end
+
+      # NOTE:
+      # if you get error like:
+      # "Invalid Resource Record: FATAL problem: InvalidCharacterString (Value should be enclosed in quotation marks) encountered with <value>"
+      # this means that the "Value" should include escape quotes.
+      # e.g. values: ["\"Something\"", "\"Other Thing\""]
+      def write_record
+        route53.change_resource_record_sets(options)
+      end
+
+      private
+
+      def options
+        change = {
+          action: 'UPSERT',
+          resource_record_set: {
+            name: label,
+            type: record_type,
+            ttl: 1,
+            resource_records: resource_record_values
+          }
+        }
+
+        {
+          hosted_zone_id: zone.id,
+          change_batch: {
+            changes: [change]
+          }
+        }
+      end
+
+      def root_domain
+        requested_domain.split(".").last(2).join(".")
+      end
+
+      def zone
+        @zone = route53.list_hosted_zones(max_items: 100)
+                      .hosted_zones
+                      .detect { |z| z.name = '#{root_domain}.' }
+      end
+
+      def route53
+        # Note: The `region` doesn't matter, because Route53 is global.
+        @route53 ||= Aws::Route53::Client.new(region: 'us-east-1')
+      end
+
+      # createt an AwsRoute53 upsert with multiple value entries
+      def resource_record_values
+        values.map do |value|
+          { value: value }
+        end
+      end
+    end
+  end
+end

--- a/lib/apartment_acme_client/dns_api/route53.rb
+++ b/lib/apartment_acme_client/dns_api/route53.rb
@@ -16,7 +16,7 @@ module ApartmentAcmeClient
 
       # array of value keys to be written
       # (for wildcard certs, you'll have one for *.example.com, and one for example.com)
-      # e.g. ["\"One\"", "\"Two\""]
+      # e.g. ["One", "Two"]
       attr_reader :values
 
       def initialize(requested_domain:, dns_record_label:, record_type:, values:)
@@ -74,7 +74,11 @@ module ApartmentAcmeClient
       # createt an AwsRoute53 upsert with multiple value entries
       def resource_record_values
         values.map do |value|
-          { value: value }
+          if value.include?("\"")
+            { value: value }
+          else
+            { value: "\"#{value}\"" }
+          end
         end
       end
     end

--- a/lib/apartment_acme_client/encryption.rb
+++ b/lib/apartment_acme_client/encryption.rb
@@ -1,11 +1,11 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 # Initially, the system is only accessible via subdomain.example.com
 # But, as we add more Conventions, we want to be able to access those also,
 # thus we will need:
-# - a.subdomain.example.com
-# - b.subdomain.example.com
-# - c.subdomain.example.com
+# - *.subdomain.example.com
 #
 # Also, each convention may add an "alias" for their convention, like:
 # - www.naucc.com
@@ -28,13 +28,16 @@ module ApartmentAcmeClient
 
     # Largely based on https://github.com/unixcharles/acme-client documentation
     def register_new(email)
-      raise StandardError.new("Private key already exists") unless @certificate_storage.private_key.nil?
+      unless @certificate_storage.private_key.nil?
+        raise StandardError, 'Private key already exists'
+      end
 
       private_key = create_private_key
 
       # Initialize the client
       new_client = ApartmentAcmeClient::AcmeClient::Proxy.singleton(
-        private_key: private_key,
+        acme_client_private_key: private_key,
+        csr_private_key: nil, # not needed for 'register' call
       )
 
       new_client.register(email)
@@ -42,22 +45,82 @@ module ApartmentAcmeClient
       @certificate_storage.save_private_key(private_key)
     end
 
-    def authorize_domains(domains)
-      successful_domains = domains.select { |domain| authorize_domain(domain) }
-      successful_domains
-    end
-
     # authorizes a domain with letsencrypt server
     # returns true on success, false otherwise.
     #
     # from https://github.com/unixcharles/acme-client/tree/master#authorize-for-domain
-    def authorize_domain(domain)
-      authorization = client.authorize(domain: domain)
+    def authorize_domain(domain_authorization)
+      if domain_authorization.http
+        authorize_domain_with_http(domain_authorization)
+      else
+        authorize_domain_with_dns(domain_authorization)
+      end
+    end
 
-      # This example is using the http-01 challenge type. Other challenges are dns-01 or tls-sni-01.
-      challenge = authorization.http01
+    # Authorize a wildcard cert domain.
+    # to do this, we have to write to the Amazon Route53 DNS entry
+    # params:
+    #  - authorizations - a list of authorizations, which may be http or dns based (ignore the http ones)
+    #  - root_domain - the url of the base domain
+    def authorize_domains_with_dns(authorizations, root_domain:)
 
-      # The http-01 method will require you to respond to a HTTP request.
+      label = nil
+      record_type = nil
+      values = []
+
+      authorizations.each do |domain_authorization|
+        next unless domain_authorization.dns
+
+        authorization = domain_authorization.dns
+        label         = "#{authorization.record_name}.#{root_domain}"
+        record_type   = authorization.record_type
+        value         = authorization.record_content
+        values << value
+      end
+
+      return unless values.any?
+
+      route53 = DnsApi::Route53.new(
+        requested_domain: root_domain,
+        dns_record_label: label,
+        record_type: record_type,
+        values: values
+      )
+
+      route53.write_record
+
+      check_dns = DnsApi::CheckDns.new(root_domain, label)
+
+      check_dns.wait_for_present(values.first)
+
+      if check_dns.check_dns(values.first)
+        # DNS is updated, proceed with cert request
+        dns_authorizations.each do |domain_authorization|
+          domain_authorization.request_validation
+
+          10.times do
+            # may be 'pending' initially
+            break if domain_authorization.status == 'valid'
+            puts "Waiting for LetsEncrypt to authorize the domain"
+
+            # Wait a bit for the server to make the request, or just blink. It should be fast.
+            sleep(2)
+            domain_authorization.reload
+          end
+        end
+      else
+        # ERROR, DNS not updated in 10 seconds?
+      end
+    end
+
+    # authorizes a single domain with letsencrypt server
+    # returns true on success, false otherwise.
+    #
+    # from https://github.com/unixcharles/acme-client/tree/master#authorize-for-domain
+    def authorize_domain_with_http(domain_authorization)
+      challenge = domain_authorization.http
+
+      # The http method will require you to respond to a HTTP request.
 
       # You can retrieve the challenge token
       challenge.token # => "some_token"
@@ -90,39 +153,69 @@ module ApartmentAcmeClient
       #  challenge = client.challenge_from_hash(JSON.parse(File.read('challenge')))
 
       # Once you are ready to serve the confirmation request you can proceed.
-      challenge.request_verification # => true
+      challenge.request_validation # => true
 
-      success = false
       10.times do
-        if challenge.verify_status == 'valid' # may be 'pending' initially
-          success = true
-          break
-        end
+        # may be 'pending' initially
+        break if challenge.status == 'valid'
+        puts "Waiting for letsencrypt to authorize the single domain"
 
         # Wait a bit for the server to make the request, or just blink. It should be fast.
-        sleep(1)
+        sleep(2)
+        challenge.reload
       end
       File.delete(full_challenge_filename)
 
-      success
+      challenge.status == 'valid'
     end
 
-    def request_certificate(common_name:, domains:)
-      client.request_certificate(common_name: common_name, domains: domains)
+    # Create an order, perform authorization for each domain, and then
+    # request the certificate.
+    # - common name is used so that there is continuity of requests over time
+    # - domains are the list of individual http-based domains to be authorized
+    # - wildcard_domain is an optional wildcard domain to be authorized via DNS Record
+    #
+    # Returns the certificate
+    def request_certificate(common_name:, domains:, wildcard_domain: nil)
+      domain_names_requested = domains
+      domain_names_requested += [wildcard_domain, "*.#{wildcard_domain}"] if wildcard_domain.present?
+      order = client.new_order(identifiers: domain_names_requested)
+
+      # Do the HTTP authorizations
+      order.authorizations.each do |authorization|
+        authorize_domain_with_http(authorization) if authorization.http
+      end
+      # Do the DNS (wildcard) authorizations
+      authorize_domains_with_dns(order.authorizations)
+
+      client.request_certificate(common_name: common_name, names: domain_names_requested, order: order)
     end
 
     private
 
     def client
       @client ||= ApartmentAcmeClient::AcmeClient::Proxy.singleton(
-        private_key: private_key,
+        acme_client_private_key: private_key,
+        csr_private_key: csr_private_key,
       )
     end
 
     # Returns a private key
-    def private_key
+    def acme_client_private_key
       private_key = @certificate_storage.private_key
       return nil unless private_key
+
+      OpenSSL::PKey::RSA.new(private_key)
+    end
+
+    def csr_private_key
+      private_key = @certificate_storage.csr_private_key
+
+      # create a new private key if one is not found
+      if private_key.nil?
+        private_key = create_private_key
+        @certificate_storage.save_csr_private_key(private_key)
+      end
 
       OpenSSL::PKey::RSA.new(private_key)
     end

--- a/lib/apartment_acme_client/encryption.rb
+++ b/lib/apartment_acme_client/encryption.rb
@@ -58,7 +58,7 @@ module ApartmentAcmeClient
 
       dns_authorizations = []
       authorizations.each do |domain_authorization|
-        next unless domain_authorization.wildcard
+        next unless domain_authorization.wildcard || domain_authorization.http.nil?
 
         dns_authorizations << domain_authorization.dns
       end
@@ -175,7 +175,7 @@ module ApartmentAcmeClient
 
       # Do the HTTP authorizations
       order.authorizations.each do |authorization|
-        authorize_domain_with_http(authorization) unless authorization.wildcard
+        encryptor.send(:authorize_domain_with_http, authorization) unless authorization.wildcard || authorization.http.nil?
       end
       # Do the DNS (wildcard) authorizations
       authorize_domains_with_dns(order.authorizations, wildcard_domain: wildcard_domain)

--- a/lib/apartment_acme_client/nginx_configuration/real.rb
+++ b/lib/apartment_acme_client/nginx_configuration/real.rb
@@ -105,7 +105,6 @@ module ApartmentAcmeClient
 
               ssl_stapling on;
               ssl_stapling_verify on;
-              ssl_trusted_certificate <%= options[:certificate_storage_folder] %>/<%= options[:cert_prefix] %>fullchain.pem;
 
               ssl_session_timeout 5m;
               <% end %>

--- a/lib/apartment_acme_client/renewal_service.rb
+++ b/lib/apartment_acme_client/renewal_service.rb
@@ -8,12 +8,11 @@ module ApartmentAcmeClient
 
       common_name = ApartmentAcmeClient.common_name || good_domains.first
 
-      # domains = ApartmentAcmeClient::Encryption.new.authorize_domains(good_domains)
-      # puts "authorized-domains list: #{domains}"
+      encryptor = ApartmentAcmeClient::Encryption.new
+      certificate = encryptor.request_certificate(common_name: common_name, domains: good_domains, wildcard_domain: ApartmentAcmeClient.wildcard_domain)
 
-      certificate = ApartmentAcmeClient::Encryption.new.request_certificate(common_name: common_name, domains: good_domains, wildcard_domain: ApartmentAcmeClient.wildcard_domain)
-
-      ApartmentAcmeClient::CertificateStorage::Proxy.singleton.store_certificate(certificate)
+      ApartmentAcmeClient::CertificateStorage::Proxy.singleton.store_certificate_string(certificate)
+      ApartmentAcmeClient::CertificateStorage::Proxy.singleton.store_csr_private_key_string(encryptor.csr_private_key_string)
 
       puts 'Restarting nginx with new certificate'
       ApartmentAcmeClient::FileManipulation::Proxy.singleton.restart_service('nginx')

--- a/lib/apartment_acme_client/renewal_service.rb
+++ b/lib/apartment_acme_client/renewal_service.rb
@@ -1,21 +1,24 @@
+# frozen_string_literal: true
+
 module ApartmentAcmeClient
   class RenewalService
     def self.run!
       good_domains, rejected_domains = ApartmentAcmeClient::DomainChecker.new.accessible_domains
       puts "All domains to be requested: #{good_domains}, invalid domains: #{rejected_domains}"
 
-      domains = ApartmentAcmeClient::Encryption.new.authorize_domains(good_domains)
-      puts "authorized-domains list: #{domains}"
+      common_name = ApartmentAcmeClient.common_name || good_domains.first
 
-      common_name = ApartmentAcmeClient.common_name ? ApartmentAcmeClient.common_name : good_domains.first
-      certificate = ApartmentAcmeClient::Encryption.new.request_certificate(common_name: common_name, domains: domains)
+      # domains = ApartmentAcmeClient::Encryption.new.authorize_domains(good_domains)
+      # puts "authorized-domains list: #{domains}"
+
+      certificate = ApartmentAcmeClient::Encryption.new.request_certificate(common_name: common_name, domains: good_domains, wildcard_domain: ApartmentAcmeClient.wildcard_domain)
 
       ApartmentAcmeClient::CertificateStorage::Proxy.singleton.store_certificate(certificate)
 
-      puts "Restarting nginx with new certificate"
-      ApartmentAcmeClient::FileManipulation::Proxy.singleton.restart_service("nginx")
+      puts 'Restarting nginx with new certificate'
+      ApartmentAcmeClient::FileManipulation::Proxy.singleton.restart_service('nginx')
 
-      puts "done."
+      puts 'done.'
     end
   end
 end

--- a/lib/apartment_acme_client/renewal_service.rb
+++ b/lib/apartment_acme_client/renewal_service.rb
@@ -9,7 +9,11 @@ module ApartmentAcmeClient
       common_name = ApartmentAcmeClient.common_name || good_domains.first
 
       encryptor = ApartmentAcmeClient::Encryption.new
-      certificate = encryptor.request_certificate(common_name: common_name, domains: good_domains, wildcard_domain: ApartmentAcmeClient.wildcard_domain)
+      certificate = encryptor.request_certificate(
+        common_name: common_name,
+        domains: good_domains,
+        wildcard_domain: ApartmentAcmeClient.wildcard_domain
+      )
 
       ApartmentAcmeClient::CertificateStorage::Proxy.singleton.store_certificate_string(certificate)
       ApartmentAcmeClient::CertificateStorage::Proxy.singleton.store_csr_private_key_string(encryptor.csr_private_key_string)

--- a/lib/apartment_acme_client/version.rb
+++ b/lib/apartment_acme_client/version.rb
@@ -1,3 +1,3 @@
 module ApartmentAcmeClient
-  VERSION = '0.0.3'
+  VERSION = '0.0.4'
 end

--- a/spec/apartment_acme_client/encryption_spec.rb
+++ b/spec/apartment_acme_client/encryption_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe ApartmentAcmeClient::Encryption do
     expect(described_class.new.request_certificate(common_name: "example.com", domains: ["a.com"])).not_to be_nil
   end
 
-  it "can call authorize_domains" do
-    expect(described_class.new.authorize_domains(["a.com"])).not_to be_nil
+  it "can call authorize_domain_with_http" do
+    expect(described_class.new.request_certificate(common_name: "a.com", domains: ["a.com"])).not_to be_nil
   end
 
   it "can call register_new" do

--- a/spec/apartment_acme_client/nginx_configuration/real_spec.rb
+++ b/spec/apartment_acme_client/nginx_configuration/real_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
-RSpec.describe ApartmentAcmeClient::NginxConfiguration::Real do
+RSpec.describe ApartmentAcmeClient::NginxConfiguration::Real do # rubocop:disable Metrics/BlockLength
   let(:root_path) { Rails.root.join("public") }
   before { ApartmentAcmeClient.certificate_storage_folder = root_path }
   before { ApartmentAcmeClient.public_folder = Rails.root.join("public") }
+  before { ApartmentAcmeClient.file_manipulation_class = Stubs::FakeFileManipulation }
 
   context "update_nginx" do
     it "can write a new file" do

--- a/spec/apartment_acme_client/stubs/fake_acme_client.rb
+++ b/spec/apartment_acme_client/stubs/fake_acme_client.rb
@@ -14,6 +14,12 @@ module Stubs
       OpenStruct.new(http01: challenge)
     end
 
+    def new_order(identifiers:)
+      OpenStruct.new(
+        authorizations: []
+      )
+    end
+
     private
 
     def challenge

--- a/spec/apartment_acme_client/stubs/fake_certificate_storage.rb
+++ b/spec/apartment_acme_client/stubs/fake_certificate_storage.rb
@@ -12,7 +12,14 @@ module Stubs
     def private_key
     end
 
+    def csr_private_key
+    end
+
     def save_private_key(private_key)
+      true
+    end
+
+    def save_csr_private_key(private_key)
       true
     end
   end

--- a/spec/apartment_acme_client/stubs/fake_certificate_storage.rb
+++ b/spec/apartment_acme_client/stubs/fake_certificate_storage.rb
@@ -1,6 +1,9 @@
 module Stubs
   class FakeCertificateStorage
-    def store_certificate(certificate)
+    def store_certificate_string(certificate)
+    end
+
+    def store_csr_private_key_string(private_key)
     end
 
     def cert_exists?


### PR DESCRIPTION
Uses ACME v2 protocol (v1 is sunset in a few months).
This also enables the use of wildcard certificates from letsencrypt, which permits us to greatly reduce the number of validations necessary to generate a new certificate.

Note: wildcard cert capability requires additional powers on the IAM user.