### PR TITLE
add delay between DNS record and LetsEncrypt auth.

### DIFF
--- a/lib/apartment_acme_client/dns_api/check_dns.rb
+++ b/lib/apartment_acme_client/dns_api/check_dns.rb
@@ -51,7 +51,7 @@ module ApartmentAcmeClient
         @nameservers
       end
 
-      def wait_for_present(value, timeout_seconds: 60)
+      def wait_for_present(value, timeout_seconds: 120)
         time = 1
         until check_dns(value)
           puts "Waiting for DNS to update"

--- a/lib/apartment_acme_client/renewal_service.rb
+++ b/lib/apartment_acme_client/renewal_service.rb
@@ -14,6 +14,10 @@ module ApartmentAcmeClient
         domains: good_domains,
         wildcard_domain: ApartmentAcmeClient.wildcard_domain
       )
+      if certificate.nil?
+        puts "ERROR, no certificate returned aborting"
+        return
+      end
 
       ApartmentAcmeClient::CertificateStorage::Proxy.singleton.store_certificate_string(certificate)
       ApartmentAcmeClient::CertificateStorage::Proxy.singleton.store_csr_private_key_string(encryptor.csr_private_key_string)


### PR DESCRIPTION
I tried to do the auth call as soon as I saw the DNS record, and LetsEncrypt
wasn't able to see the record.

This adds a delay between the 2 steps (60 seconds),
and also adds more detailed logging